### PR TITLE
Modified "get" instruction output #8

### DIFF
--- a/rhi/commands/get.py
+++ b/rhi/commands/get.py
@@ -1,3 +1,7 @@
+import json
+
+from typing import Any, Dict, List
+
 from .command import Command
 
 
@@ -6,23 +10,38 @@ class Get(Command):
         self.num: int = args.num if args.num else 0
 
     def invoke(self) -> None:
-        if self.num > 0:
-            self.get_single()
-        else:
-            self.get_all()
+        output: List[str] = []
 
-    def get_single(self) -> None:
+        if self.num > 0:
+            output = self.get_single()
+        else:
+            output = self.get_all()
+
+        print("\n".join(output))
+
+
+    def parse_line(self, one_command: Dict[str, str]) -> str:
+        if one_command["message"]:
+            return f'{one_command["command"]}   # {one_command["message"]}'
+        else:
+            return f'{one_command["command"]}'
+
+    def get_single(self) -> List[str]:
         r = self.call_get(operation=f"/get/{self.num}")
 
         result = r.json().get("result")
-        print(result)
+        return [self.parse_line(result)]
 
-    def get_all(self) -> None:
+    def get_all(self) -> List[str]:
         r = self.call_get(operation="/get/")
 
         results = r.json().get("result")
         length = len(results)
         digits = len(str(length))
 
+        output: List[str] = [] 
         for i in range(length):
-            print(f" {i+1:{digits}}: {results[i]}")
+            r = self.parse_line(results[i])
+            output.append(f" {i+1:{digits}}: {r}")
+
+        return output

--- a/rhi/config.py
+++ b/rhi/config.py
@@ -1,7 +1,7 @@
 import os
 
 ENVIRONMENT = os.getenv("ENV", "dev")
-# URL = "http://localhost:20080"
-URL = "http://192.168.1.250:20080"
+URL = "http://localhost:20080"
+#URL = "http://192.168.1.250:20080"
 HEADERS = {"content-type": "application/json"}
 HISTTIMEFORMAT = os.getenv("HISTTIMEFORMAT")

--- a/tests/commands/test_get.py
+++ b/tests/commands/test_get.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+
+import requests.models
+
+from unittest.mock import patch
+
+from rhi.commands.get import Get
+
+
+@patch('rhi.commands.get.Get.__init__')
+@patch('rhi.commands.get.Get.call_get')
+def test_get_all_output(mock_call_get, mock_get_init):
+    res = requests.models.Response()
+    res.status_code = 200
+    res.encoding = 'utf-8'
+    res._content = bytes(json.dumps({
+        'result': [
+            {'command': 'ls -alh', 'message': ''},
+            {'command': 'cat /etc/SUSE-brand', 'message': 'opensuse version file'},
+        ]}), 'utf-8')
+
+    mock_get_init.return_value = None
+    mock_call_get.return_value = res
+
+    expected = [
+        ' 1: ls -alh', 
+        ' 2: cat /etc/SUSE-brand   # opensuse version file',
+    ]
+
+    get = Get()
+    result = get.get_all()
+
+    assert result == expected
+
+@patch('rhi.commands.get.Get.__init__')
+@patch('rhi.commands.get.Get.call_get')
+def test_get_single_output(mock_call_get, mock_get_init):
+    res = requests.models.Response()
+    res.status_code = 200
+    res.encoding = 'utf-8'
+    res._content = bytes(json.dumps({
+        'result': {'command': 'cat /etc/SUSE-brand', 'message': 'opensuse version file'}
+    }), 'utf-8')
+
+    mock_get_init.return_value = None
+    mock_call_get.return_value = res
+
+    expected = ['cat /etc/SUSE-brand   # opensuse version file']
+
+    get = Get()
+    get.num = 2
+    result = get.get_single()
+
+    assert result == expected
+


### PR DESCRIPTION
modified "get" instruction output like below

```
 1: this is test line 2
 2: docker-compose -f docker-compose.dev.yml up   # docker-compose up command on local dev environment
 3: poetry config repositories.rhi https://test.pypi.org/legacy/
 4: vi /usr/lib/systemd/system/systemd-timesyncd.service   # virtualbox time sync service
 5: systemctl status systemd-timesyncd   # run systemd-timesyncd
```

messages are put at tail of command like comment format

close #8 